### PR TITLE
Fix IRC logs link, space out ReviewBoard as Review Board

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -36,12 +36,12 @@ early submission and testing system in support of test driven development.</p>
   <li><a href="http://blog.markusproject.org">Blog</a></li>
   <li><a href="http://www.markusproject.org/admin-demo">Sandbox</a></li>
   <li><a href="http://github.com/MarkUsProject/Markus">Source Code</a></li>
-  <li><a href="http://review.markusproject.org/r/">ReviewBoard</a></li>
+  <li><a href="http://review.markusproject.org/r/">Review Board</a></li>
   <li><a href="http://www.markusproject.org/dev/app_doc/">MarkUs RDoc</a></li>
   <li><a href="http://www.markusproject.org/dev/test_coverage/">Test Coverage</a></li>
   <li><a href="http://www.markusproject.org/dev/unit_tests_report.html">Units Test Report</a></li>
   <li><a href="http://www.markusproject.org/dev/functional_tests_report.html">Functional Test Report</a></li>
-  <li>IRC <a href="irc://irc.freenode.net/#markus">Channel</a> (<a href="http://www.cs.toronto.edu/~mconley/irc/markus/">Logs</a>) </li>
+  <li>IRC <a href="irc://irc.freenode.net/#markus">Channel</a> (<a href="http://www.markusproject.org/irc/">Logs</a>) </li>
   <li>Mailing list: <a href="mailto:markus-users@cs.toronto.edu">MarkUs Users</a> </li>
 </ul>
 


### PR DESCRIPTION
This stuff had been changed manually on the server, and somehow missed version control.
